### PR TITLE
Forced 2.x versions of maven-deploy-plugin and maven-install-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,4 +29,18 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <version>2.8.2</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-install-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <version>2.5.2</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Newer 3.x versions of those plugins breaks the mule packaging plugin and it's thus not possible to run mvn install or mvn deploy