### PR TITLE
Update SourcePublishingWiringFactory.java

### DIFF
--- a/src/main/java/com/mulesoft/services/graphql/internal/wiring/SourcePublishingWiringFactory.java
+++ b/src/main/java/com/mulesoft/services/graphql/internal/wiring/SourcePublishingWiringFactory.java
@@ -66,8 +66,8 @@ public class SourcePublishingWiringFactory implements WiringFactory {
 
             try {
                 //TODO - More harcoding!!
-                queue.offer(context, 1, TimeUnit.MINUTES);
-                Object result = context.awaitForResponse(1, TimeUnit.MINUTES);
+                queue.offer(context, 5, TimeUnit.MINUTES);
+                Object result = context.awaitForResponse(5, TimeUnit.MINUTES);
                 return result;
             } catch (RuntimeException ex) {
                 logger.error("Timeout wiring field", ex);


### PR DESCRIPTION
For loading the heave data for ETL process wiring is timing out within a min hence either it needs to be set cofigurable or on a higer side for API to use